### PR TITLE
Mysql connection fix and service annotation missing for bean error.

### DIFF
--- a/src/main/java/com/code/musicAPI/service/StorageService.java
+++ b/src/main/java/com/code/musicAPI/service/StorageService.java
@@ -3,9 +3,11 @@ package com.code.musicAPI.service;
 import com.code.musicAPI.model.Song;
 import com.code.musicAPI.repository.SongRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
+@Service
 public class StorageService {
 
     @Autowired

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.port=8089
 spring.datasource.username=sa
 spring.datasource.password=password
-spring.datasource.url=jdbc:mysql://mysql-standalone:3306/test
+spring.datasource.url=jdbc:mysql://localhost:3306/test
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
- Fixed the connection to mysql: You were trying to connect to a mysql-standalone which was probably a old docker container name from the tutorial I gave you. Because spring is not in a container it needs to contact mysql through the local network.
- There was a bean error because you were missing the @service annotation, which prevented spring from starting.

After these fixes spring started, I only tried the endpoint /viewall, which created the song table correctly.